### PR TITLE
Address various low audit findings

### DIFF
--- a/src/ZkMinterDelayV1.sol
+++ b/src/ZkMinterDelayV1.sol
@@ -132,12 +132,12 @@ contract ZkMinterDelayV1 is ZkMinterV1 {
     }
 
     uint48 _createdAt = uint48(block.timestamp);
-    uint256 nextRequestId = nextMintRequestId++;
+    uint256 currentRequestId = nextMintRequestId++;
 
-    mintRequests[nextRequestId] =
+    mintRequests[currentRequestId] =
       MintRequest({minter: msg.sender, to: _to, amount: _amount, createdAt: _createdAt, executed: false, vetoed: false});
 
-    emit MintRequested(nextRequestId, _to, _amount, _createdAt + mintDelay);
+    emit MintRequested(currentRequestId, _to, _amount, _createdAt + mintDelay);
   }
 
   /// @notice Executes a mint request minting the amount of tokens specified in the request for the specified to

--- a/src/ZkMinterDelayV1.sol
+++ b/src/ZkMinterDelayV1.sol
@@ -132,13 +132,14 @@ contract ZkMinterDelayV1 is ZkMinterV1 {
     }
 
     uint48 _createdAt = uint48(block.timestamp);
+    uint256 nextRequestId = nextMintRequestId++;
 
-    mintRequests[nextMintRequestId] =
+    mintRequests[nextRequestId] =
       MintRequest({minter: msg.sender, to: _to, amount: _amount, createdAt: _createdAt, executed: false, vetoed: false});
 
-    nextMintRequestId++;
 
-    emit MintRequested(nextMintRequestId, _createdAt);
+    emit MintRequested(nextRequestId, _createdAt + mintDelay);
+
   }
 
   /// @notice Executes a mint request minting the amount of tokens specified in the request for the specified to

--- a/src/ZkMinterDelayV1.sol
+++ b/src/ZkMinterDelayV1.sol
@@ -84,7 +84,7 @@ contract ZkMinterDelayV1 is ZkMinterV1 {
   //////////////////////////////////////////////////////////////*/
 
   /// @notice The next mint request id.
-  uint256 public nextMintRequestId;
+  uint256 public nextMintRequestId = 1;
 
   /// @notice The delay in seconds before minting can begin.
   uint48 public mintDelay;

--- a/src/ZkMinterDelayV1.sol
+++ b/src/ZkMinterDelayV1.sol
@@ -40,7 +40,7 @@ contract ZkMinterDelayV1 is ZkMinterV1 {
   event MintDelayUpdated(uint48 indexed previousMintDelay, uint48 indexed newMintDelay);
 
   /// @notice Emitted when a mint request is made.
-  event MintRequested(uint256 indexed mintRequestId, uint48 executableAt);
+  event MintRequested(uint256 indexed mintRequestId, address indexed to, uint256 amount, uint48 executableAt);
 
   /// @notice Emitted when a mint request is vetoed.
   event MintRequestVetoed(uint256 indexed mintRequestId);
@@ -137,9 +137,7 @@ contract ZkMinterDelayV1 is ZkMinterV1 {
     mintRequests[nextRequestId] =
       MintRequest({minter: msg.sender, to: _to, amount: _amount, createdAt: _createdAt, executed: false, vetoed: false});
 
-
-    emit MintRequested(nextRequestId, _createdAt + mintDelay);
-
+    emit MintRequested(nextRequestId, _to, _amount, _createdAt + mintDelay);
   }
 
   /// @notice Executes a mint request minting the amount of tokens specified in the request for the specified to

--- a/test/ZkMinterDelayV1.integration.t.sol
+++ b/test/ZkMinterDelayV1.integration.t.sol
@@ -73,7 +73,7 @@ contract ZkMinterDelayV1Integration is ZkBaseTest {
     vm.prank(minter);
     delayMinter.mint(_recipient, _amount);
 
-    uint256 requestId = 0; // First request
+    uint256 requestId = 1; // First request
     MintRequest memory request = delayMinter.getMintRequest(requestId);
 
     assertEq(request.minter, minter);
@@ -128,7 +128,7 @@ contract ZkMinterDelayV1Integration is ZkBaseTest {
     vm.prank(minter);
     delayMinter.mint(_recipient, _amount);
 
-    uint256 _requestId = 0;
+    uint256 _requestId = 1;
 
     // Admin vetoes the request
     vm.prank(admin);
@@ -169,7 +169,7 @@ contract ZkMinterDelayV1Integration is ZkBaseTest {
     vm.prank(minter);
     delayMinter.mint(_recipient, _amount);
 
-    uint256 requestId = 0;
+    uint256 requestId = 1;
 
     // Admin updates the delay to be longer
     vm.prank(admin);
@@ -261,7 +261,7 @@ contract ZkMinterDelayV1Integration is ZkBaseTest {
     vm.prank(minter);
     delayMinter.mint(_recipient, _amount);
 
-    uint256 requestId = 0;
+    uint256 requestId = 1;
 
     // Pause the delay minter
     vm.prank(admin);
@@ -308,7 +308,7 @@ contract ZkMinterDelayV1Integration is ZkBaseTest {
     vm.prank(minter);
     delayMinter.mint(_recipient, _amount);
 
-    uint256 requestId = 0;
+    uint256 requestId = 1;
 
     // Close the contract
     vm.prank(admin);

--- a/test/ZkMinterDelayV1.t.sol
+++ b/test/ZkMinterDelayV1.t.sol
@@ -107,7 +107,7 @@ contract Mint is ZkMinterDelayV1Test {
     _amount = _boundToRealisticAmount(_amount);
 
     vm.expectEmit();
-    emit ZkMinterDelayV1.MintRequested(1, uint48(block.timestamp));
+    emit ZkMinterDelayV1.MintRequested(0, uint48(block.timestamp) + MINT_DELAY);
 
     vm.prank(minter);
     minterDelay.mint(_to, _amount);

--- a/test/ZkMinterDelayV1.t.sol
+++ b/test/ZkMinterDelayV1.t.sol
@@ -43,7 +43,7 @@ contract Constructor is ZkMinterDelayV1Test {
     assertEq(address(_minterDelay.mintable()), address(_mintable));
     assertTrue(_minterDelay.hasRole(_minterDelay.DEFAULT_ADMIN_ROLE(), _admin));
     assertEq(_minterDelay.mintDelay(), _mintDelay);
-    assertEq(_minterDelay.nextMintRequestId(), 0);
+    assertEq(_minterDelay.nextMintRequestId(), 1);
   }
 
   function testFuzz_EmitsMinterDelayUpdatedEvent(IMintable _mintable, address _admin, uint48 _mintDelay) public {
@@ -107,7 +107,7 @@ contract Mint is ZkMinterDelayV1Test {
     _amount = _boundToRealisticAmount(_amount);
 
     vm.expectEmit();
-    emit ZkMinterDelayV1.MintRequested(0, _to, _amount, uint48(block.timestamp) + MINT_DELAY);
+    emit ZkMinterDelayV1.MintRequested(1, _to, _amount, uint48(block.timestamp) + MINT_DELAY);
 
     vm.prank(minter);
     minterDelay.mint(_to, _amount);

--- a/test/ZkMinterDelayV1.t.sol
+++ b/test/ZkMinterDelayV1.t.sol
@@ -107,7 +107,7 @@ contract Mint is ZkMinterDelayV1Test {
     _amount = _boundToRealisticAmount(_amount);
 
     vm.expectEmit();
-    emit ZkMinterDelayV1.MintRequested(0, uint48(block.timestamp) + MINT_DELAY);
+    emit ZkMinterDelayV1.MintRequested(0, _to, _amount, uint48(block.timestamp) + MINT_DELAY);
 
     vm.prank(minter);
     minterDelay.mint(_to, _amount);


### PR DESCRIPTION
- [L-01] Incorrect mint request ID emitted in MintRequested event
- [L-02] MintRequested event passes creation timestamp instead of executable timestamp
- [I-05] MintRequested event missing key parameters for effective monitoring
- This should make the first nextMintRequestId equal to 1