### PR TITLE
Fix informational issues

### DIFF
--- a/src/ZkMinterDelayV1.sol
+++ b/src/ZkMinterDelayV1.sol
@@ -177,7 +177,7 @@ contract ZkMinterDelayV1 is ZkMinterV1 {
   /// @param _newMintDelay The new mint delay in seconds.
   function updateMintDelay(uint48 _newMintDelay) external virtual {
     _checkRole(DEFAULT_ADMIN_ROLE, msg.sender);
-	_revertIfClosed();
+    _revertIfClosed();
     _updateMintDelay(_newMintDelay);
   }
 

--- a/test/ZkMinterDelayV1.t.sol
+++ b/test/ZkMinterDelayV1.t.sol
@@ -308,11 +308,11 @@ contract UpdateMintDelay is ZkMinterDelayV1Test {
 
   function testFuzz_RevertIf_ContractIsClosed(uint48 _newMintDelay) public {
     _assumeSafeUint(_newMintDelay);
-    
+
     // Close the contract first
     vm.prank(admin);
     minterDelay.close();
-    
+
     // Try to update mint delay after contract is closed
     vm.expectRevert(ZkMinterV1.ZkMinter__ContractClosed.selector);
     vm.prank(admin);


### PR DESCRIPTION
- [I-01] Veto function fails silently when request is already vetoed
- [I-03] Unused error declarations in ZkMinterDelayV1 contract
  -Note:  ZkMinterDelayV1__InvalidZeroAddress() is used in the constructor
- [I-04] Delay timing fence-post error